### PR TITLE
fix: フィルター適用中の行ズレ（コピー・編集・貼り付け・削除・フィル・検索置換）を修正

### DIFF
--- a/app/src/components/SelectionStatistics.tsx
+++ b/app/src/components/SelectionStatistics.tsx
@@ -12,21 +12,25 @@ interface StatisticsData {
 }
 
 export const SelectionStatistics: React.FC = () => {
-  const { data, selectedCell, selectedRange } = useCsvStore();
+  const { data, selectedCell, selectedRange, filters, getFilteredData } = useCsvStore();
 
   const statistics = useMemo((): StatisticsData | null => {
     if (!data) return null;
+
+    // 選択範囲の行番号は表示上の位置を指すため、フィルター適用後の行を参照する
+    const viewRows = (getFilteredData() ?? data).rows;
 
     let values: string[] = [];
 
     if (selectedCell) {
       // Single cell selected
-      values = [selectedCell.value];
+      values = [viewRows[selectedCell.row]?.[selectedCell.column] ?? selectedCell.value];
     } else if (selectedRange) {
-      // Range selected
-      for (let row = selectedRange.startRow; row <= selectedRange.endRow; row++) {
+      // Range selected（表示されている行だけを集計対象にする）
+      const endRow = Math.min(selectedRange.endRow, viewRows.length - 1);
+      for (let row = selectedRange.startRow; row <= endRow; row++) {
         for (let col = selectedRange.startColumn; col <= selectedRange.endColumn; col++) {
-          const value = data.rows[row]?.[col] || '';
+          const value = viewRows[row]?.[col] || '';
           values.push(value);
         }
       }
@@ -79,7 +83,8 @@ export const SelectionStatistics: React.FC = () => {
       average,
       hasNumericData: true
     };
-  }, [data, selectedCell, selectedRange]);
+    // filters はフィルター変更時に再計算させるための依存
+  }, [data, selectedCell, selectedRange, filters, getFilteredData]);
 
   const formatNumber = (num: number): string => {
     // Format numbers with appropriate precision

--- a/app/src/components/csv/CsvTable.tsx
+++ b/app/src/components/csv/CsvTable.tsx
@@ -98,6 +98,9 @@ export function CsvTable() {
 
   // Use filtered data for display
   const displayData = getFilteredData() || data;
+  // 選択・編集・ナビゲーションが扱う行番号は「表示上の位置」なので、
+  // セルの値や行数の参照は必ずフィルター適用後のこちらを使う
+  const displayRows = displayData?.rows ?? [];
 
   // Drag and drop functionality
   const { dragState, handlers } = useDragAndDrop({
@@ -181,7 +184,7 @@ export function CsvTable() {
         pendingInitialEdit.current = null;
       } else {
         const cellValue =
-          data.rows[editingCell.row]?.[editingCell.column] || "";
+          displayRows[editingCell.row]?.[editingCell.column] || "";
         setEditValue(cellValue);
       }
     }
@@ -403,7 +406,7 @@ export function CsvTable() {
             // Cell is not rendered yet, use virtualizer to scroll
             if (
               targetRow >= 0 &&
-              targetRow < (data?.rows.length || 0)
+              targetRow < displayRows.length
             ) {
               rowVirtualizer.scrollToIndex(targetRow, {
                 align: "center",
@@ -432,7 +435,7 @@ export function CsvTable() {
   ) => {
     if (!data) return;
 
-    const cell = { row, column, value: data.rows[row]?.[column] || "" };
+    const cell = { row, column, value: displayRows[row]?.[column] || "" };
 
     // Handle shift+click for range selection
     if (event?.shiftKey) {
@@ -551,7 +554,7 @@ export function CsvTable() {
   const handleCellDoubleClick = (row: number, column: number) => {
     if (!data) return;
 
-    const cell = { row, column, value: data.rows[row]?.[column] || "" };
+    const cell = { row, column, value: displayRows[row]?.[column] || "" };
     startEditing(cell);
   };
 
@@ -580,7 +583,7 @@ export function CsvTable() {
     event.preventDefault();
     // 右クリックしたセルが選択外なら、そのセルを単独選択（Excel挙動）
     if (!isCellInSelection(row, column)) {
-      selectCell({ row, column, value: data.rows[row]?.[column] || "" });
+      selectCell({ row, column, value: displayRows[row]?.[column] || "" });
     }
     setCellMenu({ x: event.clientX, y: event.clientY, row, column });
   };
@@ -696,15 +699,15 @@ export function CsvTable() {
               const targetRowIndex =
                 selectedCell !== null
                   ? selectedCell.row
-                  : data.rows.length > 0
-                  ? data.rows.length - 1
+                  : displayRows.length > 0
+                  ? displayRows.length - 1
                   : undefined;
 
               // Calculate the new row index before adding
               // For 'below' position: newRowIndex = targetRowIndex + 1
-              // For undefined (end): newRowIndex = data.rows.length
+              // For undefined (end): newRowIndex = displayRows.length
               const newRowIndex =
-                selectedCell !== null ? selectedCell.row + 1 : data.rows.length;
+                selectedCell !== null ? selectedCell.row + 1 : displayRows.length;
 
               addRow("below", targetRowIndex);
 
@@ -762,7 +765,7 @@ export function CsvTable() {
       const cell = {
         row: editRow,
         column: editColumn,
-        value: data.rows[editRow]?.[editColumn] || "",
+        value: displayRows[editRow]?.[editColumn] || "",
       };
       e.preventDefault();
       pendingInitialEdit.current = e.key;
@@ -782,16 +785,16 @@ export function CsvTable() {
           extendToCell = {
             row: Math.max(0, row - 1),
             column,
-            value: data.rows[Math.max(0, row - 1)]?.[column] || "",
+            value: displayRows[Math.max(0, row - 1)]?.[column] || "",
           };
           break;
         case "ArrowDown":
           e.preventDefault();
           extendToCell = {
-            row: Math.min(data.rows.length - 1, row + 1),
+            row: Math.min(displayRows.length - 1, row + 1),
             column,
             value:
-              data.rows[Math.min(data.rows.length - 1, row + 1)]?.[column] ||
+              displayRows[Math.min(displayRows.length - 1, row + 1)]?.[column] ||
               "",
           };
           break;
@@ -800,7 +803,7 @@ export function CsvTable() {
           extendToCell = {
             row,
             column: Math.max(0, column - 1),
-            value: data.rows[row]?.[Math.max(0, column - 1)] || "",
+            value: displayRows[row]?.[Math.max(0, column - 1)] || "",
           };
           break;
         case "ArrowRight":
@@ -809,7 +812,7 @@ export function CsvTable() {
             row,
             column: Math.min(data.headers.length - 1, column + 1),
             value:
-              data.rows[row]?.[Math.min(data.headers.length - 1, column + 1)] ||
+              displayRows[row]?.[Math.min(data.headers.length - 1, column + 1)] ||
               "",
           };
           break;
@@ -822,7 +825,7 @@ export function CsvTable() {
           // Scroll row into view
           if (
             extendToCell.row >= 0 &&
-            extendToCell.row < (data?.rows.length || 0)
+            extendToCell.row < displayRows.length
           ) {
             const virtualItems = rowVirtualizer.getVirtualItems();
             const virtualItem = virtualItems.find(
@@ -902,7 +905,7 @@ export function CsvTable() {
           break;
         case "ArrowDown":
           e.preventDefault();
-          newRow = data.rows.length - 1; // Jump to last row
+          newRow = displayRows.length - 1; // Jump to last row
           break;
         case "ArrowLeft":
           e.preventDefault();
@@ -921,7 +924,7 @@ export function CsvTable() {
         case "End":
           // Cmd/Ctrl + End: 最終セルへ
           e.preventDefault();
-          newRow = data.rows.length - 1;
+          newRow = displayRows.length - 1;
           newColumn = data.headers.length - 1;
           break;
         default:
@@ -937,7 +940,7 @@ export function CsvTable() {
           break;
         case "ArrowDown":
           e.preventDefault();
-          newRow = Math.min(data.rows.length - 1, row + 1);
+          newRow = Math.min(displayRows.length - 1, row + 1);
           break;
         case "ArrowLeft":
           e.preventDefault();
@@ -963,7 +966,7 @@ export function CsvTable() {
           break;
         case "PageDown":
           e.preventDefault();
-          newRow = Math.min(data.rows.length - 1, row + getPageSize());
+          newRow = Math.min(displayRows.length - 1, row + getPageSize());
           break;
         case "Enter":
         case "F2":
@@ -984,7 +987,7 @@ export function CsvTable() {
       const newCell = {
         row: newRow,
         column: newColumn,
-        value: data.rows[newRow]?.[newColumn] || "",
+        value: displayRows[newRow]?.[newColumn] || "",
       };
       selectCell(newCell);
 
@@ -999,11 +1002,11 @@ export function CsvTable() {
       if (editingCell) {
         updateCell(editingCell, editValue);
         // Move to next row after saving
-        if (data && editingCell.row < data.rows.length - 1) {
+        if (data && editingCell.row < displayRows.length - 1) {
           const nextCell = {
             row: editingCell.row + 1,
             column: editingCell.column,
-            value: data.rows[editingCell.row + 1]?.[editingCell.column] || "",
+            value: displayRows[editingCell.row + 1]?.[editingCell.column] || "",
           };
           selectCell(nextCell);
         }
@@ -1021,7 +1024,7 @@ export function CsvTable() {
           const nextCell = {
             row: editingCell.row,
             column: editingCell.column + 1,
-            value: data.rows[editingCell.row]?.[editingCell.column + 1] || "",
+            value: displayRows[editingCell.row]?.[editingCell.column + 1] || "",
           };
           selectCell(nextCell);
         }

--- a/app/src/store/csvStore.ts
+++ b/app/src/store/csvStore.ts
@@ -27,6 +27,31 @@ export function describeHistoryAction(action: HistoryAction): string {
   }
 }
 
+/**
+ * 表示上の行範囲を、元データ上の行番号リストへ展開する。
+ *
+ * テーブルの選択範囲・メニュー・キーボード操作は「画面に見えている行の位置」を
+ * インデックスとして持つため、データを書き換える前に必ずこの変換を通す。
+ * フィルターで隠れている行は結果に含まれない。
+ *
+ * @param map        表示行 → 元データ行の対応表（フィルター未適用なら null＝恒等変換）
+ * @param totalRows  元データの行数（map が null のときの上限に使う）
+ */
+function toSourceRows(
+  map: number[] | null,
+  startRow: number,
+  endRow: number,
+  totalRows: number
+): number[] {
+  const from = Math.max(0, startRow);
+  const to = Math.min(endRow, (map ? map.length : totalRows) - 1);
+  const rows: number[] = [];
+  for (let r = from; r <= to; r++) {
+    rows.push(map ? map[r] : r);
+  }
+  return rows;
+}
+
 interface CsvState {
   // Data state
   data: CsvData | null;
@@ -119,6 +144,13 @@ interface CsvState {
   removeFilter: (id: string) => void;
   clearFilters: () => void;
   getFilteredData: () => CsvData | null;
+  /**
+   * 表示行 → 元データ行の対応表（表示順）。
+   * フィルター未適用のときは null を返す（＝恒等変換。巨大な配列を作らないため）。
+   */
+  getVisibleRowMap: () => number[] | null;
+  /** 表示上の行番号を元データの行番号へ変換する（非表示・範囲外なら -1） */
+  toSourceRowIndex: (displayRow: number) => number;
 
   addSort: (sort: SortConfig) => void;
   removeSort: (index: number) => void;
@@ -442,6 +474,10 @@ export const useCsvStore = create<CsvState>()(
         const state = get();
         if (!state.data) return;
 
+        // cell.row は表示上の行番号なので、元データの行番号へ変換する
+        const sourceRow = get().toSourceRowIndex(cell.row);
+        if (sourceRow < 0) return;
+
         // Store before state for history - deep copy rows
         const beforeData = {
           ...state.data,
@@ -449,9 +485,9 @@ export const useCsvStore = create<CsvState>()(
         };
 
         const newRows = [...state.data.rows];
-        if (newRows[cell.row]) {
-          newRows[cell.row] = [...newRows[cell.row]];
-          newRows[cell.row][cell.column] = value;
+        if (newRows[sourceRow]) {
+          newRows[sourceRow] = [...newRows[sourceRow]];
+          newRows[sourceRow][cell.column] = value;
         }
 
         const afterData = {
@@ -513,23 +549,37 @@ export const useCsvStore = create<CsvState>()(
 
       clearFilters: () => set({ filters: [] }),
 
-      getFilteredData: () => {
+      getVisibleRowMap: () => {
         const state = get();
-        if (!state.data || state.filters.length === 0) {
-          return state.data;
-        }
+        if (!state.data || state.filters.length === 0) return null;
 
         const activeFilters = state.filters.filter(f => f.isActive);
-        if (activeFilters.length === 0) {
-          return state.data;
-        }
+        if (activeFilters.length === 0) return null;
 
-        const filteredRows = state.data.rows.filter(row => {
-          return activeFilters.every(filter => {
-            const cellValue = row[filter.column] || '';
-            return applyFilter(cellValue, filter);
-          });
+        const map: number[] = [];
+        state.data.rows.forEach((row, index) => {
+          const visible = activeFilters.every(filter =>
+            applyFilter(row[filter.column] || '', filter)
+          );
+          if (visible) map.push(index);
         });
+        return map;
+      },
+
+      toSourceRowIndex: (displayRow) => {
+        const map = get().getVisibleRowMap();
+        if (!map) return displayRow;
+        return displayRow >= 0 && displayRow < map.length ? map[displayRow] : -1;
+      },
+
+      getFilteredData: () => {
+        const state = get();
+        if (!state.data) return null;
+
+        const map = get().getVisibleRowMap();
+        if (!map) return state.data;
+
+        const filteredRows = map.map(index => state.data!.rows[index]);
 
         return {
           ...state.data,
@@ -623,6 +673,11 @@ export const useCsvStore = create<CsvState>()(
         const state = get();
         if (!state.data) return;
 
+        // ドラッグ位置は表示上の行位置なので、元データの行番号へ変換する
+        const sourceFrom = get().toSourceRowIndex(fromIndex);
+        const sourceTo = get().toSourceRowIndex(toIndex);
+        if (sourceFrom < 0 || sourceTo < 0 || sourceFrom === sourceTo) return;
+
         try {
           const { tauriAPI } = await import('../hooks/useTauri');
 
@@ -631,7 +686,7 @@ export const useCsvStore = create<CsvState>()(
             rows: state.data.rows.map(row => [...row])
           };
 
-          const newData = await tauriAPI.moveRow(state.data, fromIndex, toIndex);
+          const newData = await tauriAPI.moveRow(state.data, sourceFrom, sourceTo);
 
           const historyAction: HistoryAction = {
             type: 'replace_all',
@@ -788,9 +843,22 @@ export const useCsvStore = create<CsvState>()(
           return r;
         });
 
+        // 貼り付け先は表示上の行位置なので、元データの行番号へ変換する。
+        // 表示されている行を下に辿り、末尾を超えた分は新しい行として追加する。
+        const rowMap = get().getVisibleRowMap();
+        const visibleCount = rowMap ? rowMap.length : state.data.rows.length;
+
         // Paste clipboard data starting from target cell
         for (let clipRow = 0; clipRow < state.clipboard.length; clipRow++) {
-          const targetRowIndex = startRow + clipRow;
+          const displayRowIndex = startRow + clipRow;
+          let targetRowIndex: number;
+
+          if (displayRowIndex < visibleCount) {
+            targetRowIndex = rowMap ? rowMap[displayRowIndex] : displayRowIndex;
+          } else {
+            // 表示行の末尾を超える貼り付けは末尾に行を追加していく
+            targetRowIndex = newRows.length;
+          }
 
           // Extend rows if necessary
           while (targetRowIndex >= newRows.length) {
@@ -843,15 +911,28 @@ export const useCsvStore = create<CsvState>()(
         const newRows = [...state.data.rows];
         const selection = state.selectedCell || state.selectedRange || undefined;
 
+        // 選択範囲は表示上の行位置なので、元データの行番号へ変換する
+        // （フィルターで隠れている行は削除対象に含めない）
+        const rowMap = get().getVisibleRowMap();
+
         if (state.selectedCell) {
           // Delete single cell
-          if (newRows[state.selectedCell.row]) {
-            newRows[state.selectedCell.row] = [...newRows[state.selectedCell.row]];
-            newRows[state.selectedCell.row][state.selectedCell.column] = '';
+          const sourceRow = rowMap
+            ? rowMap[state.selectedCell.row] ?? -1
+            : state.selectedCell.row;
+          if (sourceRow >= 0 && newRows[sourceRow]) {
+            newRows[sourceRow] = [...newRows[sourceRow]];
+            newRows[sourceRow][state.selectedCell.column] = '';
           }
         } else if (state.selectedRange) {
           // Delete range selection
-          for (let row = state.selectedRange.startRow; row <= state.selectedRange.endRow; row++) {
+          const sourceRows = toSourceRows(
+            rowMap,
+            state.selectedRange.startRow,
+            state.selectedRange.endRow,
+            state.data.rows.length
+          );
+          for (const row of sourceRows) {
             if (newRows[row]) {
               newRows[row] = [...newRows[row]];
               for (let col = state.selectedRange.startColumn; col <= state.selectedRange.endColumn; col++) {
@@ -897,16 +978,27 @@ export const useCsvStore = create<CsvState>()(
         };
         const newRows = state.data.rows.map(row => [...row]);
 
+        // 選択範囲は表示上の行位置。フィルターで隠れている行は飛ばして、
+        // 「画面に見えている並び」でフィルする
+        const rowMap = get().getVisibleRowMap();
+
         if (sel && sel.endRow > sel.startRow) {
+          const sourceRows = toSourceRows(rowMap, sel.startRow, sel.endRow, state.data.rows.length);
+          if (sourceRows.length < 2) return;
+          const [srcRow, ...targetRows] = sourceRows;
           for (let c = sel.startColumn; c <= sel.endColumn; c++) {
-            const srcVal = newRows[sel.startRow]?.[c] ?? '';
-            for (let r = sel.startRow + 1; r <= sel.endRow; r++) {
+            const srcVal = newRows[srcRow]?.[c] ?? '';
+            for (const r of targetRows) {
               if (newRows[r]) newRows[r][c] = srcVal;
             }
           }
         } else if (state.selectedCell && state.selectedCell.row > 0) {
           const { row, column } = state.selectedCell;
-          newRows[row][column] = newRows[row - 1]?.[column] ?? '';
+          // 直上「表示行」の値をコピーする
+          const targetRow = rowMap ? rowMap[row] ?? -1 : row;
+          const aboveRow = rowMap ? rowMap[row - 1] ?? -1 : row - 1;
+          if (targetRow < 0 || aboveRow < 0 || !newRows[targetRow]) return;
+          newRows[targetRow][column] = newRows[aboveRow]?.[column] ?? '';
         } else {
           return; // フィル対象なし
         }
@@ -966,20 +1058,25 @@ export const useCsvStore = create<CsvState>()(
           return Array.from({ length: count }, (_, k) => srcValues[k % srcValues.length]);
         };
 
+        // origin / target は表示上の行位置。フィルターで隠れている行は対象外にする
+        const rowMap = get().getVisibleRowMap();
+        const totalRows = state.data.rows.length;
+        const originRows = toSourceRows(rowMap, origin.r1, origin.r2, totalRows);
+        if (originRows.length === 0) return;
+
         if (grewDown) {
-          const count = target.endRow - origin.r2;
+          const targetRows = toSourceRows(rowMap, origin.r2 + 1, target.endRow, totalRows);
+          if (targetRows.length === 0) return;
           for (let c = origin.c1; c <= origin.c2; c++) {
-            const src: string[] = [];
-            for (let r = origin.r1; r <= origin.r2; r++) src.push(newRows[r]?.[c] ?? '');
-            const filled = extrapolate(src, count);
-            for (let k = 0; k < count; k++) {
-              const r = origin.r2 + 1 + k;
+            const src = originRows.map(r => newRows[r]?.[c] ?? '');
+            const filled = extrapolate(src, targetRows.length);
+            targetRows.forEach((r, k) => {
               if (newRows[r]) newRows[r][c] = filled[k];
-            }
+            });
           }
         } else if (grewRight) {
           const count = target.endColumn - origin.c2;
-          for (let r = origin.r1; r <= origin.r2; r++) {
+          for (const r of originRows) {
             if (!newRows[r]) continue;
             const src: string[] = [];
             for (let c = origin.c1; c <= origin.c2; c++) src.push(newRows[r][c] ?? '');
@@ -1104,17 +1201,21 @@ export const useCsvStore = create<CsvState>()(
         const newRows = [...state.data.rows];
         const newRow = new Array(state.data.headers.length).fill('');
 
+        // rowIndex は表示上の行位置なので、元データの行番号へ変換する
+        const sourceIndex =
+          rowIndex === undefined ? -1 : get().toSourceRowIndex(rowIndex);
+
         // Handle empty table case
         let insertIndex: number;
         if (state.data.rows.length === 0) {
           // If table is empty, always insert at index 0
           insertIndex = 0;
-        } else if (rowIndex === undefined) {
-          // If rowIndex is not provided, append to the end
+        } else if (sourceIndex < 0) {
+          // rowIndex 未指定、または表示範囲外なら末尾に追加
           insertIndex = state.data.rows.length;
         } else {
           // Normal case: insert above or below the specified row
-          insertIndex = position === 'above' ? rowIndex : rowIndex + 1;
+          insertIndex = position === 'above' ? sourceIndex : sourceIndex + 1;
         }
         newRows.splice(insertIndex, 0, newRow);
 
@@ -1155,11 +1256,16 @@ export const useCsvStore = create<CsvState>()(
           new Array(state.data!.headers.length).fill('')
         );
 
+        // rowIndex は表示上の行位置なので、元データの行番号へ変換する
+        const sourceIndex = get().toSourceRowIndex(rowIndex);
+
         let insertIndex: number;
         if (state.data.rows.length === 0) {
           insertIndex = 0;
+        } else if (sourceIndex < 0) {
+          insertIndex = state.data.rows.length;
         } else {
-          insertIndex = position === 'above' ? rowIndex : rowIndex + 1;
+          insertIndex = position === 'above' ? sourceIndex : sourceIndex + 1;
         }
         newRows.splice(insertIndex, 0, ...newBlankRows);
 
@@ -1183,12 +1289,16 @@ export const useCsvStore = create<CsvState>()(
         const state = get();
         if (!state.data) return;
 
+        // rowIndex は表示上の行位置なので、元データの行番号へ変換する
+        const sourceIndex = get().toSourceRowIndex(rowIndex);
+        if (sourceIndex < 0) return;
+
         const beforeData = {
           ...state.data,
           rows: state.data.rows.map(row => [...row])
         };
         const newRows = [...state.data.rows];
-        newRows.splice(rowIndex, 1);
+        newRows.splice(sourceIndex, 1);
 
         const afterData = {
           ...state.data,
@@ -1223,8 +1333,15 @@ export const useCsvStore = create<CsvState>()(
           rows: state.data.rows.map(row => [...row])
         };
 
+        // rowIndices は表示上の行位置なので、元データの行番号へ変換する
+        const rowMap = get().getVisibleRowMap();
+        const sourceIndices = rowMap
+          ? rowIndices.map(i => (i >= 0 && i < rowMap.length ? rowMap[i] : -1)).filter(i => i >= 0)
+          : rowIndices;
+        if (sourceIndices.length === 0) return;
+
         // 重複排除 & 降順ソートしてから splice することで index ズレを防ぐ
-        const sorted = [...new Set(rowIndices)].sort((a, b) => b - a);
+        const sorted = [...new Set(sourceIndices)].sort((a, b) => b - a);
         const newRows = [...state.data.rows];
         sorted.forEach(i => {
           if (i >= 0 && i < newRows.length) newRows.splice(i, 1);
@@ -1262,15 +1379,19 @@ export const useCsvStore = create<CsvState>()(
 
       duplicateRow: (rowIndex) => {
         const state = get();
-        if (!state.data || !state.data.rows[rowIndex]) return;
+        if (!state.data) return;
+
+        // rowIndex は表示上の行位置なので、元データの行番号へ変換する
+        const sourceIndex = get().toSourceRowIndex(rowIndex);
+        if (sourceIndex < 0 || !state.data.rows[sourceIndex]) return;
 
         const beforeData = {
           ...state.data,
           rows: state.data.rows.map(row => [...row])
         };
         const newRows = [...state.data.rows];
-        const duplicatedRow = [...state.data.rows[rowIndex]];
-        newRows.splice(rowIndex + 1, 0, duplicatedRow);
+        const duplicatedRow = [...state.data.rows[sourceIndex]];
+        newRows.splice(sourceIndex + 1, 0, duplicatedRow);
 
         const afterData = {
           ...state.data,
@@ -1607,8 +1728,12 @@ export const useCsvStore = create<CsvState>()(
           }
         }
 
-        // Search through all rows and columns
-        data.rows.forEach((row, rowIndex) => {
+        // フィルター適用中は表示されている行だけを検索対象にする。
+        // ここで得られる rowIndex は表示上の行位置（＝選択やスクロールと同じ座標系）。
+        const viewRows = (get().getFilteredData() ?? data).rows;
+
+        // Search through all visible rows and columns
+        viewRows.forEach((row, rowIndex) => {
           const columnsToSearch = columnIndex !== undefined ? [columnIndex] : row.map((_, idx) => idx);
 
           columnsToSearch.forEach((colIdx) => {
@@ -1694,7 +1819,11 @@ export const useCsvStore = create<CsvState>()(
         if (!data || searchResults.length === 0 || currentSearchIndex < 0) return;
 
         const currentResult = searchResults[currentSearchIndex];
-        const { row, column, value } = currentResult;
+        const { column, value } = currentResult;
+
+        // 検索結果の row は表示上の行位置なので、元データの行番号へ変換する
+        const row = get().toSourceRowIndex(currentResult.row);
+        if (row < 0 || !data.rows[row]) return;
 
         // Save state for undo
         const beforeData = JSON.parse(JSON.stringify(data));
@@ -1771,8 +1900,15 @@ export const useCsvStore = create<CsvState>()(
 
         const { caseSensitive, wholeWord, regex } = searchOptions;
 
+        // 検索結果の row は表示上の行位置なので、元データの行番号へ変換する
+        const rowMap = get().getVisibleRowMap();
+
         searchResults.forEach(result => {
-          const { row, column, value } = result;
+          const { column, value } = result;
+          const row = rowMap
+            ? (result.row >= 0 && result.row < rowMap.length ? rowMap[result.row] : -1)
+            : result.row;
+          if (row < 0 || !newData.rows[row]) return;
           let newValue = value;
 
           if (regex) {

--- a/app/src/store/csvStore.ts
+++ b/app/src/store/csvStore.ts
@@ -336,15 +336,18 @@ export const useCsvStore = create<CsvState>()(
             ? prev.anchorColumn ?? prev.startColumn
             : columnIndex;
 
+        // フィルター適用中は表示されている行数を基準にする
+        const lastRow = ((get().getFilteredData() ?? state.data).rows.length) - 1;
+
         const selection: CsvSelection = {
           startRow: 0,
           startColumn: Math.min(anchor, columnIndex),
-          endRow: state.data.rows.length - 1,
+          endRow: lastRow,
           endColumn: Math.max(anchor, columnIndex),
           type: 'column',
           anchorRow: 0,
           anchorColumn: anchor,
-          focusRow: state.data.rows.length - 1,
+          focusRow: lastRow,
           focusColumn: columnIndex
         };
         set({ selectedRange: selection, selectedCell: null });
@@ -354,15 +357,18 @@ export const useCsvStore = create<CsvState>()(
         const state = get();
         if (!state.data) return;
 
+        // フィルター適用中は表示されている行数を基準にする
+        const lastRow = ((get().getFilteredData() ?? state.data).rows.length) - 1;
+
         const selection: CsvSelection = {
           startRow: 0,
           startColumn: 0,
-          endRow: state.data.rows.length - 1,
+          endRow: lastRow,
           endColumn: state.data.headers.length - 1,
           type: 'range',
           anchorRow: 0,
           anchorColumn: 0,
-          focusRow: state.data.rows.length - 1,
+          focusRow: lastRow,
           focusColumn: state.data.headers.length - 1
         };
 
@@ -690,17 +696,23 @@ export const useCsvStore = create<CsvState>()(
         const state = get();
         if (!state.data) return;
 
+        // 選択範囲の行インデックスは「表示上の位置」を指すため、
+        // フィルター適用中は生データではなく絞り込み後の行を参照する
+        const viewRows = (get().getFilteredData() ?? state.data).rows;
+
         let cellsToClip: string[][] = [];
 
         if (state.selectedCell) {
           // Copy single cell
-          cellsToClip = [[state.selectedCell.value]];
+          const { row, column, value } = state.selectedCell;
+          cellsToClip = [[viewRows[row]?.[column] ?? value]];
         } else if (state.selectedRange) {
-          // Copy range selection
-          for (let row = state.selectedRange.startRow; row <= state.selectedRange.endRow; row++) {
+          // Copy range selection（表示行数を超える範囲は切り詰める）
+          const endRow = Math.min(state.selectedRange.endRow, viewRows.length - 1);
+          for (let row = state.selectedRange.startRow; row <= endRow; row++) {
             const rowData: string[] = [];
             for (let col = state.selectedRange.startColumn; col <= state.selectedRange.endColumn; col++) {
-              rowData.push(state.data.rows[row]?.[col] || '');
+              rowData.push(viewRows[row]?.[col] || '');
             }
             cellsToClip.push(rowData);
           }


### PR DESCRIPTION
## 概要

フィルターで絞り込んだ状態でコピーすると、表示されている選択範囲ではなく元データの同じ位置の行がコピーされる問題を修正しました。あわせて、同じ原因（表示上の行番号を生データの添字として使っていた）で壊れていた編集・貼り付け・削除・フィル・検索置換・統計も修正しています。

## 原因

選択範囲・右クリックメニュー・キーボード操作が持つ行番号は「画面に見えている行の位置」（`CsvTable.tsx` の `displayData = getFilteredData()` に対するインデックス）です。一方でストア側の各操作はそれをそのまま `data.rows[row]` の添字として使っていたため、フィルター適用中は常に別の行を読み書きしていました。

## 変更内容

### 1. 表示行 → 元データ行の変換を追加（`csvStore.ts`）

- `getVisibleRowMap()` … 表示行 → 元データ行の対応表（フィルター未適用時は `null` を返し、巨大な恒等配列を作らない）
- `toSourceRowIndex(displayRow)` … 表示上の行番号を元データの行番号へ変換
- `toSourceRows(map, startRow, endRow, totalRows)` … 表示上の行範囲を元データの行番号リストへ展開（フィルターで隠れている行は含めない）
- `getFilteredData()` は `getVisibleRowMap()` を使う実装に統一

### 2. 変換を通すようにした操作

| 対象 | 修正内容 |
| --- | --- |
| `copySelection` | 表示行から値を取得。範囲の終端を表示行数でクランプ |
| `updateCell` | 編集対象を元データ行へ変換 |
| `paste` | 表示行を辿って貼り付け。表示末尾を超えた分は末尾に行を追加 |
| `deleteSelection` / `cutSelection` | 表示されている行だけをクリア |
| `fillDown` / `fillFromHandle` | 画面に見えている並びでフィル（隠れ行は対象外・系列も表示行基準） |
| `addRow` / `insertRows` / `deleteRow` / `deleteRows` / `duplicateRow` / `moveRow` | 挿入・削除・移動位置を元データ行へ変換 |
| `performSearch` / `replaceCurrentResult` / `replaceAllResults` | 検索は表示行のみを対象にし、置換は変換した元データ行へ書き込む |
| `selectColumn` / `selectAll` | 選択範囲の終端行を表示行数基準に変更（非表示分が空行として付いてこない） |

### 3. 表示側（`CsvTable.tsx` / `SelectionStatistics.tsx`）

- セル値の参照とキーボードナビゲーションの境界判定を `displayRows`（フィルター適用後）に統一
- 選択範囲の統計も表示行から集計

## 検証

- `pnpm build`（tsc + vite）が通ることを確認
- 本リポジトリにはテストランナーが無いため、esbuild でストアをバンドルして Node 上で挙動を確認する使い捨てスクリプトを書き、28 ケースすべて PASS することを確認しました（コミットには含めていません）
  - フィルターで 3/6 行だけ表示した状態で、コピー・単一セルコピー・Cmd+A コピー・編集・貼り付け（末尾超過含む）・削除・切り取り・フィル（タイル/系列）・行の挿入/削除/複製・検索/置換が、いずれも「表示されている行」に対して正しく効くこと
  - フィルター未適用時に既存挙動が変わっていないこと

### 手動確認手順

1. CSV を開き、フィルターで行を絞り込む
2. 表示されている範囲を選択して Cmd+C → 貼り付け先の内容が画面表示と一致する
3. 絞り込んだ状態でセル編集・貼り付け・Delete・Cmd+D が、隠れている行ではなく表示中の行に効く
4. 行の挿入/削除/複製、検索・置換も表示中の行を対象にする

## 残っている既知の制限

- 行番号のヘッダーはフィルター中も 1,2,3… と表示位置の連番を表示します（Excel は元の行番号を表示）。データ破損ではなく表示上の差分のため、本 PR では変更していません。
- ドラッグでの行並べ替えをフィルター適用中に行った場合、移動先は「見えている行の元データ位置」になります（隠れ行をまたぐ移動の見え方は Excel と完全一致ではありません）。
